### PR TITLE
Improve markdown table styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -134,11 +134,23 @@
   overflow-wrap: break-word;
 }
 
-.markdown-content code {
-  white-space: pre-wrap;
-  word-break: break-word;
-  overflow-wrap: break-word;
-}
+  .markdown-content code {
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: break-word;
+  }
+
+  /* Table styling for markdown content */
+  .markdown-content table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .markdown-content th,
+  .markdown-content td {
+    border: 1px solid #ffffff;
+    padding: 2px;
+  }
 
 /* Ensure proper spacing in markdown content */
 .markdown-content .katex-display {


### PR DESCRIPTION
## Summary
- add default table borders and padding for Markdown content

## Testing
- `npm install`
- `npm run lint` *(fails: 9 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684298841a60832e9a28c4c5f6439242